### PR TITLE
Rename repo

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Package: hu.es-progress.number-grouping
+Package: number-grouping
 Copyright (C) 2020, Sandor Semsey <sandor@es-progress.hu>
 Licensed under the GNU Affero Public License 3.0 (below).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# hu.es-progress.number-grouping
+# number-grouping
 
-![CI](https://github.com/reflexive-communications/hu.es-progress.number-grouping/workflows/CI/badge.svg)
+![CI](https://github.com/reflexive-communications/number-grouping/workflows/CI/badge.svg)
 
 ## Before
 
@@ -27,7 +27,7 @@ Sysadmins and developers may clone the [Git](https://en.wikipedia.org/wiki/Git) 
 with the command-line tool [cv](https://github.com/civicrm/cv).
 
 ```bash
-git clone https://github.com/reflexive-communications/hu.es-progress.number-grouping.git
+git clone https://github.com/reflexive-communications/number-grouping.git
 cv en number_grouping
 ```
 

--- a/info.xml
+++ b/info.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<extension key="hu.es-progress.number-grouping" type="module">
+<extension key="number-grouping" type="module">
     <file>number_grouping</file>
     <name>Number grouping</name>
     <description>Format numbers in custom contact tokens</description>
@@ -9,13 +9,13 @@
         <email>sandor@es-progress.hu</email>
     </maintainer>
     <urls>
-        <url desc="Main Extension Page">https://github.com/reflexive-communications/hu.es-progress.number-grouping</url>
-        <url desc="Documentation">https://github.com/reflexive-communications/hu.es-progress.number-grouping</url>
-        <url desc="Support">https://github.com/reflexive-communications/hu.es-progress.number-grouping/issues</url>
+        <url desc="Main Extension Page">https://github.com/reflexive-communications/number-grouping</url>
+        <url desc="Documentation">https://github.com/reflexive-communications/number-grouping</url>
+        <url desc="Support">https://github.com/reflexive-communications/number-grouping/issues</url>
         <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
     </urls>
-    <releaseDate>2021-04-15</releaseDate>
-    <version>2.0.0</version>
+    <releaseDate>2021-04-19</releaseDate>
+    <version>2.0.1</version>
     <develStage>stable</develStage>
     <compatibility>
         <ver>5.0</ver>

--- a/info.xml
+++ b/info.xml
@@ -15,7 +15,7 @@
         <url desc="Licensing">http://www.gnu.org/licenses/agpl-3.0.html</url>
     </urls>
     <releaseDate>2021-04-19</releaseDate>
-    <version>2.0.1</version>
+    <version>3.0.0</version>
     <develStage>stable</develStage>
     <compatibility>
         <ver>5.0</ver>

--- a/number_grouping.civix.php
+++ b/number_grouping.civix.php
@@ -10,7 +10,7 @@ class CRM_NumberGrouping_ExtensionUtil
 {
     const SHORT_NAME = "number_grouping";
 
-    const LONG_NAME = "hu.es-progress.number-grouping";
+    const LONG_NAME = "number-grouping";
 
     const CLASS_PREFIX = "CRM_NumberGrouping";
 


### PR DESCRIPTION
`hu.es-progress.number-grouping` --> `number-grouping`

If this PR get merged I'll change repo name in GitHub also.